### PR TITLE
Fix `this.readConfig is not a function` errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ module.exports = {
         revisionKey: function (context) {
           return context.commandOptions.revision || (context.revisionData && context.revisionData.revisionKey);
         },
-        deployClient: function (context) {
-          var mysqlOptions = this.pluginConfig;
-          mysqlOptions.port = this.readConfig('port');
+        deployClient: function (context, pluginHelper) {
+          var mysqlOptions = this;
+          mysqlOptions.port = pluginHelper.readConfig('port');
           var mysqlLib = context._mysqlLib;
 
           return new MySQL(mysqlOptions, mysqlLib);


### PR DESCRIPTION
This PR is just the minimal change needed to eliminate some `this.readConfig is not a function` errors I was seeing. It seems that `ember-cli-deploy-plugin` 0.2.7 [changed the `this` context in config functions](https://github.com/ember-cli-deploy/ember-cli-deploy-plugin/commit/6b3040ff0e304a7af1934541f6e32bcf69636217), which broke `deployClient`.